### PR TITLE
Add package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "complete-vuejs-3",
   "version": "1.0.0",
   "main": "index.js",
-  "license": "MIT",
+  "license": "MIT",  
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "serve": "vite preview"
+  },
   "dependencies": {
     "@vue/compiler-sfc": "3.0.7",
     "vue": "^3.0.7",


### PR DESCRIPTION
I don't know how you did it before but this is the only way I could get vite to build the development server. I did a basic comparison between this repo and the vitejs.dev common app install process.