### PR TITLE
adds a devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/ubuntu/.devcontainer/base.Dockerfile
+
+# [Choice] Ubuntu version (use hirsuite or bionic on local arm64/Apple Silicon): hirsute, focal, bionic
+ARG VARIANT="hirsute"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends npm \
+    && apt-get -y autoremove && apt-get -y clean
+
+RUN npm install -g n
+RUN n v12.18.3
+RUN npm install -g yarn@1.22.10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.202.3/containers/ubuntu
+{
+	"name": "Ubuntu",
+	"runArgs": ["--init"],
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Ubuntu version: hirsute, focal, bionic
+		// Use hirsute or bionic on local arm64/Apple Silicon.
+		"args": { "VARIANT": "focal" }
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"jcbuisson.vue",
+		"octref.vetur"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/ts-custom.d.ts
+++ b/ts-custom.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+    import { defineComponent } from 'vue';
+    const component: ReturnType<typeof defineComponent>;
+    export default component;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,29 @@
+{
+    "include": [
+        "src/**/*.ts",
+        "src/**/*.vue",
+        "test/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ],
+    "files": [
+        "ts-custom.d.ts"
+    ],
+    "types": [
+        "jest"
+    ],
+    "compilerOptions": {
+        "outDir": "./dist/",
+        "target": "es5",
+        "module": "esnext",
+        "moduleResolution": "node",
+        "esModuleInterop": true,
+        "strict": true,
+        "noImplicitReturns": true,
+        "allowJs": false,
+        "sourceMap": true,
+        "pretty": true,
+        "removeComments": true
+    }
+}


### PR DESCRIPTION
I put some time into installing not the exact version, removing them again until suff actually workded.
My Idea was to just contribute a devcontainer so that the versions of the dependencies are already correctly installed there and nobody has to try out stuff on their own system where they might already have other npm or yarn versions installed.